### PR TITLE
Fix extra global Primes

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -53,7 +53,8 @@ export class PrimePCActor extends Actor
 
 		// If the actor lacks an ID, then it's in the process of being created
 		// but doesn't yet exist. We'll create it's items on the next pass, otherwise
-		// we'll end up duplicating the world items.
+		// we'll end up "duplicating" the world items as they'll be created with a
+		// null ID.
 		if (this.isVersion2() && this.id !== null)
 		{
 			await this._prepareCharacterDataV2(actorSystemData, actorData);
@@ -521,11 +522,8 @@ export class PrimePCActor extends Actor
 
 			if (actorItemsToCreate.length > 0)
 			{
-				let createdItemDocuments = await this.createEmbeddedDocuments("Item", actorItemsToCreate).then(() => {
-					console.log("Created STAT ItemDocuments - promise callback: ", createdItemDocuments);
-					//this.update()
-				});
-				console.log("Created STAT ItemDocuments - main sequence: ", createdItemDocuments);
+				let createdItemDocuments = await this.createEmbeddedDocuments("Item", actorItemsToCreate)
+				console.log("Created stat ItemDocuments", createdItemDocuments);
 			}
 			else
 			{

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -51,7 +51,10 @@ export class PrimePCActor extends Actor
 	{
 		const actorSystemData = actorData.system;
 
-		if (this.isVersion2())
+		// If the actor lacks an ID, then it's in the process of being created
+		// but doesn't yet exist. We'll create it's items on the next pass, otherwise
+		// we'll end up duplicating the world items.
+		if (this.isVersion2() && this.id !== null)
 		{
 			await this._prepareCharacterDataV2(actorSystemData, actorData);
 		}
@@ -503,7 +506,6 @@ export class PrimePCActor extends Actor
 		let actorItemsToCreate = []
 		let instancedItems = {};
 		let statItem = null;
-		let createdItemDocuments = null;
 		if (ItemDirectory && ItemDirectory.collection)	// Sometimes not defined when integrated.
 		{
 			ItemDirectory.collection.forEach((item, key, items) =>
@@ -519,11 +521,11 @@ export class PrimePCActor extends Actor
 
 			if (actorItemsToCreate.length > 0)
 			{
-				createdItemDocuments = await this.createEmbeddedDocuments("Item", actorItemsToCreate);
-				console.error("Created STAT ItemDocuments: ", createdItemDocuments);
-				if (createdItemDocuments[0].parent.type !== "character") {
-					console.error("Ooops, I did a bad thing...", createdItemDocuments)
-				}
+				let createdItemDocuments = await this.createEmbeddedDocuments("Item", actorItemsToCreate).then(() => {
+					console.log("Created STAT ItemDocuments - promise callback: ", createdItemDocuments);
+					//this.update()
+				});
+				console.log("Created STAT ItemDocuments - main sequence: ", createdItemDocuments);
 			}
 			else
 			{

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -10,8 +10,9 @@ export class PrimePCActor extends Actor
 	/**
 	 * Augment the basic actor data with additional dynamic data.
 	 */
-	async prepareData()
+	prepareData()
 	{
+		console.log("Prepare data");
 		super.prepareData();
 
 		// TODO: Refactor this away.
@@ -23,7 +24,7 @@ export class PrimePCActor extends Actor
 		if (actorData.type === 'character')
 		{
 			this._checkV2CharacterUpgrade();
-			await this._prepareCharacterData(actorData);
+			this._prepareCharacterData(actorData);
 		}
 	}
 
@@ -189,10 +190,12 @@ export class PrimePCActor extends Actor
 		let results = {};
 		if (this.isVersion2())
 		{
+			console.log("getTypeSortedPrimesAndRefinements - Getting v2")
 			results = this.getTypeSortedPrimesAndRefinementsV2();
 		}
 		else
 		{
+			console.log("getTypeSortedPrimesAndRefinements - Getting v1")
 			results = this.getTypeSortedPrimesAndRefinementsV1();
 		}
 		return results;
@@ -466,14 +469,10 @@ export class PrimePCActor extends Actor
 	async _getStatsObjects(items, statType)
 	{
 		let matchingStatItems = {};
-		// let count = 0;
-		// let currItem = null;
 		let statItem = null;
 		let atLeastOneStatFound = false;	// If we've found one prime, then the other stats are on their way asyncronously.
-		// while (count < items.length)
 		items.forEach((currItem)=> 
 		{
-			// currItem = items[count];
 			if (currItem.type == statType)
 			{
 				statItem = this._getItemDataAsStat(currItem);
@@ -489,7 +488,9 @@ export class PrimePCActor extends Actor
 		{
 			// This is a property to prevent large amounts of object being created to debug an issue with object scoping.
 			this.statRetrievalAttempted = true;
+			console.log("About to request world stats");
 			matchingStatItems = await this._getStatObjectsFromWorld(statType);
+			console.log("World stats requested and cloned");
 		}
 
 		return matchingStatItems;
@@ -519,7 +520,10 @@ export class PrimePCActor extends Actor
 			if (actorItemsToCreate.length > 0)
 			{
 				createdItemDocuments = await this.createEmbeddedDocuments("Item", actorItemsToCreate);
-				console.log("createdItemDocuments: ", createdItemDocuments);
+				console.error("Created STAT ItemDocuments: ", createdItemDocuments);
+				if (createdItemDocuments[0].parent.type !== "character") {
+					console.error("Ooops, I did a bad thing...", createdItemDocuments)
+				}
 			}
 			else
 			{

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -65,8 +65,6 @@ export class PrimeItemSheet extends ItemSheet {
     data.system = this.item.system;
 
     data.id = this.item.id;
-    data.dataAsString = JSON.stringify(data, null, "\t");
-    
 
     return data;
   }

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -64,6 +64,10 @@ export class PrimeItemSheet extends ItemSheet {
 
     data.system = this.item.system;
 
+    data.id = this.item.id;
+    data.dataAsString = JSON.stringify(data, null, "\t");
+    
+
     return data;
   }
 

--- a/templates/actor/partials/sheet/actor-primes-and-refinements.html
+++ b/templates/actor/partials/sheet/actor-primes-and-refinements.html
@@ -5,7 +5,7 @@
         <div class="blockTitle">Primes</div>
         {{/ifCond}}
         {{#each typeGroup.primes as |prime key|}}
-        <div class="primeWrapper {{prime.customisableStatClass}} {{prime.defaultItemClass}}" title="{{prime.itemID}} - {{convertHTMLForTitle prime.description 150}}&#xD;*DOUBLE CLICK TO EDIT VALUE*">
+        <div class="primeWrapper {{prime.customisableStatClass}} {{prime.defaultItemClass}}" title="{{convertHTMLForTitle prime.description 150}}&#xD;*DOUBLE CLICK TO EDIT VALUE*">
 			<a class="deleteItemIcon" data-item-id={{prime.itemID}} title="Delete prime"><i class="fas fa-trash"></i></a>
 			<a class="showStatInfoIcon" data-item-id={{prime.itemID}} data-sourceKey="{{prime.sourceKey}}"><i class="fas fa-info-circle fa-xs"></i></a>
             <label for="data.primes.{{key}}.value">{{prime.title}}</label>

--- a/templates/actor/partials/sheet/actor-primes-and-refinements.html
+++ b/templates/actor/partials/sheet/actor-primes-and-refinements.html
@@ -5,7 +5,7 @@
         <div class="blockTitle">Primes</div>
         {{/ifCond}}
         {{#each typeGroup.primes as |prime key|}}
-        <div class="primeWrapper {{prime.customisableStatClass}} {{prime.defaultItemClass}}" title="{{convertHTMLForTitle prime.description 150}}&#xD;*DOUBLE CLICK TO EDIT VALUE*">
+        <div class="primeWrapper {{prime.customisableStatClass}} {{prime.defaultItemClass}}" title="{{prime.itemID}} - {{convertHTMLForTitle prime.description 150}}&#xD;*DOUBLE CLICK TO EDIT VALUE*">
 			<a class="deleteItemIcon" data-item-id={{prime.itemID}} title="Delete prime"><i class="fas fa-trash"></i></a>
 			<a class="showStatInfoIcon" data-item-id={{prime.itemID}} data-sourceKey="{{prime.sourceKey}}"><i class="fas fa-info-circle fa-xs"></i></a>
             <label for="data.primes.{{key}}.value">{{prime.title}}</label>

--- a/templates/item/partials/sheet/item-metadata.html
+++ b/templates/item/partials/sheet/item-metadata.html
@@ -1,5 +1,6 @@
 <div class="block bottomBlockTitle metaDataBlock flexColumn flexCenter">
 	<div class="blockTitle">Entry metadata</div>
 	<div>Author: {{system.creator}} | Created: {{system.created}}</div>
-	<div></div>Updater: {{system.updater}} | Updated: {{system.updated}}</div>
+	<div>Updater: {{system.updater}} | Updated: {{system.updated}}</div>
+	<div style="user-select: all;">System ID: {{id}}</div>
 </div>


### PR DESCRIPTION
Fix for bug where duplicates of Prime stat items were being created each time a character was made. This was caused by an attempt to create the items before the actor object was actually created. As it lacked an ID at this point, the objects were made without a parent and thus assumed to be global items.

This only became apparent upon refreshing the Foundry instance, presumably as the items are only audited on application start?