### PR TITLE
Fixing stat object, Soul/XP calculation and action point handling.

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -323,7 +323,7 @@ export class PrimePCActorSheet extends ActorSheet
 			sheetData.actor.system.actionPoints.value = 0;
 		}
 
-		var result = await this.actor.update({...sheetData.actor});
+		await this.actor.update({...sheetData.actor});
 	}
 
 	async updateInjuryTotal(event)

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -304,26 +304,26 @@ export class PrimePCActorSheet extends ActorSheet
 	{
 		const input = $(event.delegateTarget);
 		const value = input.val();
-		const data = super.getData();
+		const sheetData = super.getData();
 		const checked = input.prop("checked");
 		const inputParent = input.parent();
-		data.data.actionPoints.lastTotal = data.data.actionPoints.value;
+		sheetData.actor.system.actionPoints.lastTotal = sheetData.actor.system.actionPoints.value;
 
 		if (checked || (!checked && !inputParent.hasClass("currentPointTotal")))
 		{
-			data.data.actionPoints.value = parseInt(value);
+			sheetData.actor.system.actionPoints.value = parseInt(value);
 		}
 		else
 		{
-			data.data.actionPoints.value = parseInt(value) - 1;
+			sheetData.actor.system.actionPoints.value = parseInt(value) - 1;
 		}
 
-		if (data.data.actionPoints.value < 0)
+		if (sheetData.actor.system.actionPoints.value < 0)
 		{
-			data.data.actionPoints.value = 0;
+			sheetData.actor.system.actionPoints.value = 0;
 		}
 
-		var result = await this.actor.update(data.actor);
+		var result = await this.actor.update({...sheetData.actor});
 	}
 
 	async updateInjuryTotal(event)

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -552,7 +552,7 @@ export class PrimePCActor extends Actor
 	{
 		let sourceItem = null;
 		let itemTitle = itemData.name;
-		let itemDescription = itemData.description;
+		let itemDescription = itemData.system.description;
 		if (ItemDirectory.collection && !itemData.system.customisable)
 		{
 			sourceItem = ItemDirectory.collection.get(itemData.system.sourceKey);
@@ -570,18 +570,19 @@ export class PrimePCActor extends Actor
 
 		let statData =
 		{
-			"value": itemData.value,
-			"max": itemData.max,
-			"type" : itemData.statType,
+			"value": itemData.system.value,
+			"max": itemData.system.max,
+			"type" : itemData.system.statType,
 			"title": itemTitle,
-			"description": itemData.customisable ? "*EDITABLE STAT, CLICK INFO TO EDIT* \n" + itemDescription : itemDescription,
+			"description": itemData.system.customisable ? "*EDITABLE STAT, CLICK INFO TO EDIT* \n" + itemDescription : itemDescription,
 			"sourceKey": itemData.system.sourceKey,
 			"itemID": itemData.id,
 			"itemBasedStat" : true,
-			"customisableStatClass" : itemData.customisable ? "customisableStat" : "",
-			"defaultItemClass" : itemData.default ? "defaultStat" : "expandedStat",
+			"customisableStatClass" : itemData.system.customisable ? "customisableStat" : "",
+			"defaultItemClass" : itemData.system.default ? "defaultStat" : "expandedStat",
 		}
 
+		// TODO: Is this legacy? Can't see it on the new data shape.
 		if (itemData.related)
 		{
 			statData.related = itemData.related;

--- a/templates/actor/partials/sheet/actor-action-points.html
+++ b/templates/actor/partials/sheet/actor-action-points.html
@@ -1,9 +1,9 @@
 <div class="{{partialClasses}} actionPoints block flexColumn">
     <div class="blockTitle"><span>Action points</span></div>
     <div class="metaValueContent actionPointsWrapper flexGrow">
-        {{#for 0 data.actionPoints.max 1}}
-        <div class='actionPointWrapper{{addStateClasses this ../data.actionPoints}}'>
-            <input id="actionPoint{{this}}" value="{{this}}" class="actionPointCheckbox" type="checkbox" name="actionPoints" {{itemSelected this ../data.actionPoints.value}}/>
+        {{#for 0 data.system.actionPoints.max 1}}
+        <div class='actionPointWrapper{{addStateClasses this ../data.system.actionPoints}}'>
+            <input id="actionPoint{{this}}" value="{{this}}" class="actionPointCheckbox" type="checkbox" name="actionPoints" {{itemSelected this ../data.system.actionPoints.value}}/>
             <label for="actionPoint{{this}}">{{this}}</label>
         </div>
         {{/for}}

--- a/templates/actor/partials/sheet/actor-experience-points.html
+++ b/templates/actor/partials/sheet/actor-experience-points.html
@@ -1,6 +1,6 @@
 <div class="{{partialClasses}} block bottomBlockTitle flexRow flexCenter verticalCenter">
     <div class="blockTitle">XP</div>
-    <div class="metaValueContent hasTooltip" title="Initial: {{data.xp.initial}}, Awarded: {{data.xp.awarded}}, Spent: {{data.xp.spent}}">
-        {{data.xp.value}}
+    <div class="metaValueContent hasTooltip" title="Initial: {{data.system.xp.initial}}, Awarded: {{data.system.xp.awarded}}, Spent: {{data.system.xp.spent}}">
+        {{data.system.xp.value}}
     </div>
 </div>

--- a/templates/actor/partials/sheet/actor-mental-health.html
+++ b/templates/actor/partials/sheet/actor-mental-health.html
@@ -2,16 +2,16 @@
     <div class="flexRow flexStart block topHalfBlock">
         <div class="blockTitle">Mind</div>
         <div class="cell25 flexColumn intellectBlock">
-            <label for="data.mind.psyche.value" class="shrinkFontForNarrow">Psyche</label>
+            <label for="data.system.mind.psyche.value" class="shrinkFontForNarrow">Psyche</label>
             <div class="metaValueContent flexRow flexEnd mindIntellectWrapper">
-                <input type="text" class="bigNumberInput" name="data.mind.psyche.value" value="{{data.mind.psyche.value}}" data-dtype="Number" data-min="0" data-max="{{data.mind.psyche.max}}" data-lastValue="{{data.mind.psyche.value}}"/>
-                <span class="mindMaxIntellect">Max: {{data.mind.psyche.max}}</span>
+                <input type="text" class="bigNumberInput" name="data.system.mind.psyche.value" value="{{data.system.mind.psyche.value}}" data-dtype="Number" data-min="0" data-max="{{data.system.mind.psyche.max}}" data-lastValue="{{data.system.mind.psyche.value}}"/>
+                <span class="mindMaxIntellect">Max: {{data.system.mind.psyche.max}}</span>
             </div>
         </div>
         <div class="cell25 flexColumn flexCenter">
             <label class="shrinkFontForNarrow">Insanities</label>
             <div class="metaValueContent flexRow flexCenter">
-                <div class="bigNumberText">{{data.mind.insanities.value}} / {{data.mind.insanities.max}}</div>
+                <div class="bigNumberText">{{data.system.mind.insanities.value}} / {{data.system.mind.insanities.max}}</div>
             </div>
         </div>
     </div>
@@ -23,17 +23,17 @@
     <div class="insanitiesBlock block rightBlockTitle flexColumn">
         <div class="blockTitle"><span>Insanities</span></div>
 
-        {{#for 1 data.mind.insanities.max 1}}
+        {{#for 1 data.system.mind.insanities.max 1}}
         <div class="flexRow insanityRow">
             <div class="couchIcon flexRow flexStart verticalCenter"><a class="healInsanity" title="Heal this insanity" data-insanity-index="{{this}}"><i class="fas fa-couch"></i></a></div>
-            <select name="insanitySelect{{this}}" class="insanitySelect" {{itemEnabled this ../data.mind.insanities.value}} data-insanity-index="{{this}}">
+            <select name="insanitySelect{{this}}" class="insanitySelect" {{itemEnabled this ../data.system.mind.insanities.value}} data-insanity-index="{{this}}">
                 <option value="null"></option>
 				{{#each ../actorTables.mentalConditions}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
             </select>
-            <div class="insanityCheckBoxWrapper flexRow flexCenter verticalCenter{{addStateClasses this ../data.mind.insanities}}">
-                <input type="checkbox" id="insanityCheckbox{{this}}" name="insanityCheckboxes" class="insanityCheckbox" value="{{this}}" {{itemSelected this ../data.mind.insanities.value}}/>
+            <div class="insanityCheckBoxWrapper flexRow flexCenter verticalCenter{{addStateClasses this ../data.system.mind.insanities}}">
+                <input type="checkbox" id="insanityCheckbox{{this}}" name="insanityCheckboxes" class="insanityCheckbox" value="{{this}}" {{itemSelected this ../data.system.mind.insanities.value}}/>
                 <label for="insanityCheckbox{{this}}" class="flexRow flexCenter verticalCenter">{{this}}</label>
             </div>
         </div>
@@ -43,15 +43,15 @@
         <div class="blockTitle">Wards</div>
         <div class="cell25 flexColumn intellectBlock">
             <div class="metaValueContent flexRow flexEnd mindArmourIntellectWrapper">
-                <input type="text" class="bigNumberInput" name="data.ward.psyche.value" value="{{data.ward.psyche.value}}" data-dtype="Number" data-min="0" data-max="{{data.ward.psyche.max}}" data-lastValue="{{data.ward.psyche.value}}"/>
-                <span class="mindArmourMaxIntellect">Max: {{data.ward.psyche.max}}</span>
+                <input type="text" class="bigNumberInput" name="data.system.ward.psyche.value" value="{{data.system.ward.psyche.value}}" data-dtype="Number" data-min="0" data-max="{{data.system.ward.psyche.max}}" data-lastValue="{{data.system.ward.psyche.value}}"/>
+                <span class="mindArmourMaxIntellect">Max: {{data.system.ward.psyche.max}}</span>
             </div>
             <div class="mindArmourIntellectLabel shrinkFontForNarrow">Psyche</div>
         </div>
         <div class="cell25 flexColumn flexCenter">
             <div class="metaValueContent flexRow flexCenter">
-                <!-- <input type="text" class="bigNumberInput" name="data.mindArmour.coverage.value" value="{{data.mindArmour.coverage.value}}" data-dtype="Number" data-min="0" data-max="{{data.mindArmour.coverage.max}}" data-lastValue="{{data.mindArmour.coverage.value}}"/> -->
-                <div class="bigNumberText">{{data.ward.stability.value}}</div>
+                <!-- <input type="text" class="bigNumberInput" name="data.system.mindArmour.coverage.value" value="{{data.system.mindArmour.coverage.value}}" data-dtype="Number" data-min="0" data-max="{{data.system.mindArmour.coverage.max}}" data-lastValue="{{data.system.mindArmour.coverage.value}}"/> -->
+                <div class="bigNumberText">{{data.system.ward.stability.value}}</div>
             </div>
             <div class="shrinkFontForNarrow">Stability</div>
         </div>

--- a/templates/actor/partials/sheet/actor-physical-health.html
+++ b/templates/actor/partials/sheet/actor-physical-health.html
@@ -4,14 +4,14 @@
         <div class="cell25 flexColumn flexCenter">
             <label class="shrinkFontForNarrow">Wounds</label>
             <div class="metaValueContent flexRow flexCenter">
-                <div class="bigNumberText">{{data.health.wounds.value}} / {{data.health.wounds.max}}</div>
+                <div class="bigNumberText">{{data.system.health.wounds.value}} / {{data.system.health.wounds.max}}</div>
             </div>
         </div>
         <div class="cell25 flexColumn resilienceBlock">
-            <label for="data.wounds.value" class="shrinkFontForNarrow">Resilience</label>
+            <label for="data.system.wounds.value" class="shrinkFontForNarrow">Resilience</label>
             <div class="metaValueContent flexRow healthResilienceWrapper">
-                <input type="text" class="bigNumberInput" name="data.health.resilience.value" value="{{data.health.resilience.value}}" data-dtype="Number" data-min="0" data-max="{{data.health.resilience.max}}" data-lastValue="{{data.health.resilience.value}}"/>
-                <span class="healthMaxResilience">Max: {{data.health.resilience.max}}</span>
+                <input type="text" class="bigNumberInput" name="data.system.health.resilience.value" value="{{data.system.health.resilience.value}}" data-dtype="Number" data-min="0" data-max="{{data.system.health.resilience.max}}" data-lastValue="{{data.system.health.resilience.value}}"/>
+                <span class="healthMaxResilience">Max: {{data.system.health.resilience.max}}</span>
             </div>
         </div>
     </div>
@@ -22,13 +22,13 @@
     <div class="injuriesBlock block leftBlockTitle flexColumn">
         <div class="blockTitle"><span>Wounds</span></div>
 
-        {{#for 1 data.health.wounds.max 1}}
+        {{#for 1 data.system.health.wounds.max 1}}
         <div class="flexRow injuryRow">
-            <div class="injuryCheckBoxWrapper flexRow flexCenter verticalCenter{{addStateClasses this ../data.health.wounds}}">
-                <input type="checkbox" id="injuryCheckbox{{this}}" name="injuryCheckboxes" class="injuryCheckbox" value="{{this}}" {{itemSelected this ../data.health.wounds.value}}/>
+            <div class="injuryCheckBoxWrapper flexRow flexCenter verticalCenter{{addStateClasses this ../data.system.health.wounds}}">
+                <input type="checkbox" id="injuryCheckbox{{this}}" name="injuryCheckboxes" class="injuryCheckbox" value="{{this}}" {{itemSelected this ../data.system.health.wounds.value}}/>
                 <label for="injuryCheckbox{{this}}" class="flexRow flexCenter verticalCenter">{{this}}</label>
             </div>
-            <select name="injurySelect{{this}}" class="injurySelect" {{itemEnabled this ../data.health.wounds.value}} data-injury-index="{{this}}">
+            <select name="injurySelect{{this}}" class="injurySelect" {{itemEnabled this ../data.system.health.wounds.value}} data-injury-index="{{this}}">
                 <option value="0"></option>
 				{{#each ../actorTables.woundConditions}}
 				<option value="{{this.key}}">{{this.title}}</option>
@@ -42,15 +42,15 @@
         <div class="blockTitle">Armour</div>
         <div class="cell25 flexColumn flexCenter">
             <div class="metaValueContent flexRow flexCenter">
-                <!-- <input type="text" class="bigNumberInput" name="data.armour.coverage.value" value="{{data.armour.coverage.value}}" data-dtype="Number" data-min="0" data-max="{{data.armour.coverage.max}}" data-lastValue="{{data.armour.coverage.value}}"/> -->
-                <div class="bigNumberText">{{data.armour.protection.value}}</div>
+                <!-- <input type="text" class="bigNumberInput" name="data.system.armour.coverage.value" value="{{data.system.armour.coverage.value}}" data-dtype="Number" data-min="0" data-max="{{data.system.armour.coverage.max}}" data-lastValue="{{data.system.armour.coverage.value}}"/> -->
+                <div class="bigNumberText">{{data.system.armour.protection.value}}</div>
             </div>
             <div class="shrinkFontForNarrow">Protection</div>
         </div>
         <div class="cell25 flexColumn resilienceBlock">
             <div class="metaValueContent flexRow armourResilienceWrapper">
-                <input type="text" class="bigNumberInput" name="data.armour.resilience.value" value="{{data.armour.resilience.value}}" data-dtype="Number" data-min="0" data-max="{{data.armour.resilience.max}}" data-lastValue="{{data.armour.resilience.value}}"/>
-                <span class="armourMaxResilience">Max: {{data.armour.resilience.max}}</span>
+                <input type="text" class="bigNumberInput" name="data.system.armour.resilience.value" value="{{data.system.armour.resilience.value}}" data-dtype="Number" data-min="0" data-max="{{data.system.armour.resilience.max}}" data-lastValue="{{data.system.armour.resilience.value}}"/>
+                <span class="armourMaxResilience">Max: {{data.system.armour.resilience.max}}</span>
             </div>
             <div class="shrinkFontForNarrow">Resilience</div>
         </div>

--- a/templates/actor/partials/sheet/actor-soul-points.html
+++ b/templates/actor/partials/sheet/actor-soul-points.html
@@ -1,6 +1,6 @@
 <div class="{{partialClasses}} block bottomBlockTitle flexRow flexCenter verticalCenter">
     <div class="blockTitle">Soul</div>
-    <div class="metaValueContent hasTooltip" title="Initial: {{data.system.soul.initial}}, Awarded: {{data.system.soul.awarded}}, Spent: {{data.soul.system.spent}}">
+    <div class="metaValueContent hasTooltip" title="Initial: {{data.system.soul.initial}}, Awarded: {{data.system.soul.awarded}}, Spent: {{data.system.soul.spent}}">
         {{data.system.soul.value}}
     </div>
     <div class="burnSoulpoint">

--- a/templates/actor/partials/sheet/actor-soul-points.html
+++ b/templates/actor/partials/sheet/actor-soul-points.html
@@ -1,7 +1,7 @@
 <div class="{{partialClasses}} block bottomBlockTitle flexRow flexCenter verticalCenter">
     <div class="blockTitle">Soul</div>
-    <div class="metaValueContent hasTooltip" title="Initial: {{data.soul.initial}}, Awarded: {{data.soul.awarded}}, Spent: {{data.soul.spent}}">
-        {{data.soul.value}}
+    <div class="metaValueContent hasTooltip" title="Initial: {{data.system.soul.initial}}, Awarded: {{data.system.soul.awarded}}, Spent: {{data.soul.system.spent}}">
+        {{data.system.soul.value}}
     </div>
     <div class="burnSoulpoint">
         <i class="game-icon game-icon-fire-silhouette icon-md"></i>


### PR DESCRIPTION
Fixing stat object (the object derived from the stat item that's used internally)
Fixed Soul/XP calculation
Fixed action point display & updating.
Fixed pathing for physical and mental health values in the templates.

NOTE: There is a line `await this.actor.update({...sheetData.actor});` - this was required to prevent a foundry error complaining about setting a private _id property. Seems a spread into new object is enough to create a "data only" version of their classes, which the update function is happier digesting? TBC!