### PR TITLE
Fixes for items and action display in character sheet

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -357,7 +357,7 @@ export class PrimePCActor extends Actor
 	checkPerkActionUnlock(whatPerk, whatAction)
 	{
 		var count = 0
-		while (count < whatPerk.effects.length)
+		while (whatPerk.effects && count < whatPerk.effects.length)
 		{
 			let currPerkEffect = whatPerk.effects[count];
 
@@ -382,9 +382,9 @@ export class PrimePCActor extends Actor
 			while (count < ownedPerkClones.length)
 			{
 				var currPerk = ownedPerkClones[count];
-				if (currPerk.data.cost.attributeType == perkCostType)
+				if (currPerk.system.cost.attributeType == perkCostType)
 				{
-					totalCost += currPerk.data.cost.amount;
+					totalCost += currPerk.system.cost.amount;
 				}
 				count++;
 			}

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -318,6 +318,7 @@ export class PrimePCActor extends Actor
 				var isAllowedForCharacter = this.isAllowedForCharacter(item)
 				if (isAllowedForCharacter)
 				{
+					item.itemID = item._id;
 					typeSortedActions[actionType].push(item);
 				}
 			}

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -478,8 +478,7 @@ export class PrimeItemSheet extends ItemSheet {
 
   async _updateObject(event, data) {
     this.checkMetaData(data);
-    var result = await super._updateObject(event, data);
-    //return result;
+    await super._updateObject(event, data);
   }
 
   checkMetaData(data) {
@@ -583,12 +582,12 @@ export class PrimeItemSheet extends ItemSheet {
       updateData.flags[checkboxKey] = checked;
 
       var effectToUpdate = await this.item.effects.get(effectID);
-      var result = await effectToUpdate.update(updateData);
+      await effectToUpdate.update(updateData);
     } else {
       var effectData = this.getBlankEffectByType(checkboxType);
       effectData.flags[checkboxKey] = checked;
 
-      var result = await ActiveEffect.create(effectData, this.item).create();
+      await ActiveEffect.create(effectData, this.item);
     }
   }
 
@@ -656,7 +655,12 @@ export class PrimeItemSheet extends ItemSheet {
 
     var effectData = this.getBlankEffectByType(effectType);
 
-    var result = await ActiveEffect.create(effectData, this.item).create();
+    //var result = await ActiveEffect.create(effectData, this.item);
+    var result = ActiveEffect.create({
+      ...effectData,
+      origin: this.item.id
+    }, {parent: this.item});
+
     console.log("Created? Result: ", result);
   }
 

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -63,8 +63,6 @@ export class PrimeItemSheet extends ItemSheet {
     sheetData.settingDescriptionHTML = this.item.system.settingDescription;
 
     sheetData.id = this.item.id;
-
-    sheetData.actor = this.item;
     sheetData.actor = this.actor;
     sheetData.system = this.item.system;
 

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -42,31 +42,36 @@ export class PrimeItemSheet extends ItemSheet {
 
   /** @override */
   getData() {
-    let data = super.getData();
-    data.itemTables = PrimeTables.cloneAndTranslateTables("items");
-    data.coreTables = PrimeTables.cloneAndTranslateTables("core");
-    data.perkTables = PrimeTables.cloneAndTranslateTables("perks");
-    data.actionTables = PrimeTables.cloneAndTranslateTables("actions");
-    data.actorTables = PrimeTables.cloneAndTranslateTables("actor");
+    let sheetData = super.getData();
+    sheetData.itemTables = PrimeTables.cloneAndTranslateTables("items");
+    sheetData.coreTables = PrimeTables.cloneAndTranslateTables("core");
+    sheetData.perkTables = PrimeTables.cloneAndTranslateTables("perks");
+    sheetData.actionTables = PrimeTables.cloneAndTranslateTables("actions");
+    sheetData.actorTables = PrimeTables.cloneAndTranslateTables("actor");
 
-    this.addItemTypeData(data);
-    data.checkboxGroupStates = this.checkboxGroupStates;
+    this.addItemTypeData(sheetData);
+    sheetData.checkboxGroupStates = this.checkboxGroupStates;
 
-    data.isOwned = this.item.isOwned;
-    data.owningCharacterName = null;
+    sheetData.isOwned = this.item.isOwned;
+    sheetData.owningCharacterName = null;
 
     if (this.actor) {
-      data.owningCharacterName = this.actor.name;
+      sheetData.owningCharacterName = this.actor.name;
     }
 
-    data.descriptionHTML = this.item.system.description;
-    data.settingDescriptionHTML = this.item.system.settingDescription;
+    sheetData.descriptionHTML = this.item.system.description;
+    sheetData.settingDescriptionHTML = this.item.system.settingDescription;
 
-    data.system = this.item.system;
+    sheetData.id = this.item.id;
 
-    data.id = this.item.id;
+    sheetData.actor = this.item;
+    sheetData.actor = this.actor;
+    sheetData.system = this.item.system;
 
-    return data;
+    const source = this.item.toObject();
+    sheetData.source = source.system;
+
+    return sheetData;
   }
 
   addItemTypeData(data) {

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -55,6 +55,8 @@ export class PrimeItem extends Item
 		let itemClone = $.extend(true, {}, this);
 		this.processItem(itemClone);
 
+		itemClone.itemID = this.id;
+
 		return itemClone;
 	}
 

--- a/module/prime_handlebars.js
+++ b/module/prime_handlebars.js
@@ -10,7 +10,7 @@ var primeHandlebarsPartialsPaths =
 	"actorPrimesAndRefinements": "systems/prime/templates/actor/partials/sheet/actor-primes-and-refinements.html",
 	"actorSoulPoints": "systems/prime/templates/actor/partials/sheet/actor-soul-points.html",
 	"actorActionsList": "systems/prime/templates/actor/partials/sheet/actor-actions-list.html",
-	
+
 	"actorTabDescription": "systems/prime/templates/actor/partials/tabs/actor-description-tab.html",
 	"actorTabCombat": "systems/prime/templates/actor/partials/tabs/actor-combat-tab.html",
 	"actorTabInventory": "systems/prime/templates/actor/partials/tabs/actor-inventory-tab.html",
@@ -231,4 +231,9 @@ Handlebars.registerHelper('cropToLength', function(value, cropLength)
 		return value.substring(0, cropLength) + '...';
 	}
 	return value;
+});
+
+// Usage: {{log this}}
+Handlebars.registerHelper("log", function(messageData) {
+	console.log(`HB log: ${messageData}`, messageData);
 });

--- a/templates/item/item-action-sheet.html
+++ b/templates/item/item-action-sheet.html
@@ -10,9 +10,9 @@
 				<input name="name" type="text" value="{{item.name}}" placeholder="Name" />
 			</h1>
 			<div class="cell100 flexRow verticalCenter flexBetween lastRow">
-				<label class="cell30" for="data.setting">{{localize "PRIME.core_setting"}}:</label>
-				<select name="data.setting" id="data.setting" class="itemRarity cell70">
-					{{#select data.setting}}
+				<label class="cell30" for="system.setting">{{localize "PRIME.core_setting"}}:</label>
+				<select name="system.setting" id="system.setting" class="itemRarity cell70">
+					{{#select system.setting}}
 					{{#each coreTables.settings}}
 					<option value="{{this.key}}">{{this.title}}</option>
 					{{/each}}
@@ -26,14 +26,14 @@
 		<div class="blockTitle">Action details</div>
 
 		<div class="cell30 flexRow flexBetween verticalCenter">
-			<label for="data.points" class="resource-label cell50 rightAlign">AP cost:</label>
-			<input type="text" id="data.points" name="data.points" class="cell50" value="{{data.points}}" data-dtype="Number" data-min="0" data-max="6"/>
+			<label for="system.points" class="resource-label cell50 rightAlign">AP cost:</label>
+			<input type="text" id="system.points" name="system.points" class="cell50" value="{{system.points}}" data-dtype="Number" data-min="0" data-max="6"/>
 		</div>
 
 		<div class="cell50 flexRow flexBetween verticalCenter">
-			<label for="data.type" class="resource-label cell20 rightAlign">Type:</label>
-			<select id="data.type" name="data.type" class="cell80" data-effect-id="{{effectID}}" data-effect-flag-key="path">
-				{{#select data.type}}
+			<label for="system.type" class="resource-label cell20 rightAlign">Type:</label>
+			<select id="system.type" name="system.type" class="cell80" data-effect-id="{{effectID}}" data-effect-flag-key="path">
+				{{#select system.type}}
 				{{#each actionTables.actionTypes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -42,8 +42,8 @@
 		</div>
 
 		<div class="cell20 flexRow flexBetween verticalCenter">
-			<label for="data.default" class="resource-label cell80 rightAlign" title="Action is available to all characters by default.">Default:</label>
-			<input type="checkbox" id="data.default" name="data.default" class="cell20" {{checked data.default}}/>
+			<label for="system.default" class="resource-label cell80 rightAlign" title="Action is available to all characters by default.">Default:</label>
+			<input type="checkbox" id="system.default" name="system.default" class="cell20" {{checked system.default}}/>
 		</div>
 	</div>
 
@@ -56,8 +56,8 @@
 				<div class="actionEffectIndex">{{effect.actualCount}}</div>
 				{{log effect}}
 				<div class="cell100 flexRow flexBetween verticalCenter">
-					<label for="data.effects.{{key}}.effectSubType" class="resource-label cell30 rightAlign">Type:</label>
-					<select id="data.effects.{{key}}.effectSubType" name="data.effects.{{key}}.effectSubType" class="cell70 effectFormElement" data-effect-id="{{effectID}}" data-effect-flag-key="effectSubType">
+					<label for="system.effects.{{key}}.effectSubType" class="resource-label cell30 rightAlign">Type:</label>
+					<select id="system.effects.{{key}}.effectSubType" name="system.effects.{{key}}.effectSubType" class="cell70 effectFormElement" data-effect-id="{{effectID}}" data-effect-flag-key="effectSubType">
 						{{#select effect.effectSubType}}
 						{{#each ../actionTables.effectTypes}}
 						<option value="{{this.key}}">{{this.title}}</option>
@@ -67,8 +67,8 @@
 				</div>
 
 				<div class="cell100 flexRow flexBetween verticalCenter">
-					<label for="data.effects.{{key}}.path" class="resource-label cell30 rightAlign">Target:</label>
-					<select id="data.effects.{{key}}.path" name="data.effects.{{key}}.path" class="cell70 effectFormElement" data-effect-id="{{effectID}}" data-effect-flag-key="path">
+					<label for="system.effects.{{key}}.path" class="resource-label cell30 rightAlign">Target:</label>
+					<select id="system.effects.{{key}}.path" name="system.effects.{{key}}.path" class="cell70 effectFormElement" data-effect-id="{{effectID}}" data-effect-flag-key="path">
 						{{#select effect.path}}
 						{{#each effect.dynamicDataForEffectTarget}}
 						<option value="{{this.key}}">{{this.title}}</option>
@@ -78,8 +78,8 @@
 				</div>
 
 				<div class="cell100 flexRow flexBetween verticalCenter lastRow">
-					<label for="data.effects.{{key}}.value" class="resource-label cell30 rightAlign">Value:</label>
-					<input type="text" id="data.effects.{{key}}.value" name="data.effects.{{key}}.value" class="cell70 effectFormElement" data-effect-id="{{effectID}}" data-effect-flag-key="value" value="{{effect.value}}" data-dtype="Number" data-min="-10" data-max="10"/>
+					<label for="system.effects.{{key}}.value" class="resource-label cell30 rightAlign">Value:</label>
+					<input type="text" id="system.effects.{{key}}.value" name="system.effects.{{key}}.value" class="cell70 effectFormElement" data-effect-id="{{effectID}}" data-effect-flag-key="value" value="{{effect.value}}" data-dtype="Number" data-min="-10" data-max="10"/>
 				</div>
 
 				<a class="removeEffectIcon" data-effect-id="{{effectID}}"><i class="fas fa-trash"></i></a>

--- a/templates/item/item-armour-sheet.html
+++ b/templates/item/item-armour-sheet.html
@@ -6,14 +6,14 @@
 
 		{{> itemBasic }}
 	</div>
-	
+
 	<div class="flexRow flexWrap block infoBlock flexBetween">
 		<div class="blockTitle">Armour details</div>
-		
+
 		<div class="cell100 flexRow verticalCenter flexBetween">
-			<label for="data.armourType" class="resource-label cell30">Type:</label>
-			<select name="data.armourType" class="itemValueType cell70">
-				{{#select data.armourType}}
+			<label for="system.armourType" class="resource-label cell30">Type:</label>
+			<select name="system.armourType" class="itemValueType cell70">
+				{{#select system.armourType}}
 				{{#each itemTables.armour.types}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -22,13 +22,13 @@
 		</div>
 
 		<div class="cell50 flexRow verticalCenter flexBetween">
-			<label for="data.protection" class="resource-label cell40">Protection:</label>
-			<input class="cell60" type="text" id="data.protection" name="data.protection" value="{{data.protection}}" data-dtype="Number" data-min="0" data-max="5"/>
+			<label for="system.protection" class="resource-label cell40">Protection:</label>
+			<input class="cell60" type="text" id="system.protection" name="system.protection" value="{{system.protection}}" data-dtype="Number" data-min="0" data-max="5"/>
 		</div>
 
 		<div class="cell50 flexRow verticalCenter flexBetween">
-			<label for="data.armourResilience" class="resource-label cell70">Armour resilience:</label>
-			<input type="text" id="data.armourResilience" name="data.armourResilience" class="cell30" value="{{data.armourResilience}}" data-dtype="Number" data-min="0" data-max="5"/>
+			<label for="system.armourResilience" class="resource-label cell70">Armour resilience:</label>
+			<input type="text" id="system.armourResilience" name="system.armourResilience" class="cell30" value="{{system.armourResilience}}" data-dtype="Number" data-min="0" data-max="5"/>
 		</div>
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.keywords}}" data-checkbox-group="keywords">
@@ -44,7 +44,7 @@
 			{{#each checkboxGroups.keywords.optionsData as |keyword key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{keyword.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle keyword.description}}">{{keyword.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="data.keywords.{{key}}" value="{{keyword.key}}" {{checked keyword.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="system.keywords.{{key}}" value="{{keyword.key}}" {{checked keyword.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -62,7 +62,7 @@
 			{{#each checkboxGroups.untrainedPenalty.optionsData as |untrainedPenalty key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{untrainedPenalty.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle untrainedPenalty.description}}">{{untrainedPenalty.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{untrainedPenalty.effectID}}" data-group-type="checkbox-untrained" type="checkbox" id="{{untrainedPenalty.key}}" name="data.untrainedPenalty" value="{{untrainedPenalty.key}}" {{checked untrainedPenalty.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{untrainedPenalty.effectID}}" data-group-type="checkbox-untrained" type="checkbox" id="{{untrainedPenalty.key}}" name="system.untrainedPenalty" value="{{untrainedPenalty.key}}" {{checked untrainedPenalty.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -71,7 +71,7 @@
 	{{> itemValue }}
 
 	{{> itemEffects }}
-		
+
 	{{> itemDescription }}
 
 	{{> itemMetadata }}

--- a/templates/item/item-item-sheet.html
+++ b/templates/item/item-item-sheet.html
@@ -5,7 +5,7 @@
 		</div>
 		{{> itemBasic }}
 	</div>
-		
+
 	{{> itemValue }}
 
 	{{> itemEffects }}

--- a/templates/item/item-melee-weapon-sheet.html
+++ b/templates/item/item-melee-weapon-sheet.html
@@ -5,15 +5,15 @@
 		</div>
 		{{> itemBasic }}
 	</div>
-	
+
 	<div class="flexRow flexWrap block infoBlock">
 		<div class="blockTitle">Weapon details</div>
-		
+
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.weaponSize" class="resource-label cell50">Size:</label>
-			<!--<input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />-->
-			<select name="data.weaponSize" class="weaponSize cell50">
-				{{#select data.weaponSize}}
+			<label for="system.weaponSize" class="resource-label cell50">Size:</label>
+			<!--<input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />-->
+			<select name="system.weaponSize" class="weaponSize cell50">
+				{{#select system.weaponSize}}
 				{{#each itemTables.weapons.sizes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -21,10 +21,10 @@
 			</select>
 		</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.weaponType" class="resource-label cell50">Type:</label>
-			<!--<input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />-->
-			<select id="data.weaponType" name="data.weaponType" class="cell50">
-				{{#select data.weaponType}}
+			<label for="system.weaponType" class="resource-label cell50">Type:</label>
+			<!--<input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />-->
+			<select id="system.weaponType" name="system.weaponType" class="cell50">
+				{{#select system.weaponType}}
 				{{#each itemTables.weapons.meleeTypes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -32,13 +32,13 @@
 			</select>
 		</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.damageRating" class="resource-label cell50">Damage rating:</label>
-			<input type="text" id="data.damageRating" name="data.damageRating" class="cell50" value="{{data.damageRating}}" data-dtype="Number" data-min="-5" data-max="5"/>
+			<label for="system.damageRating" class="resource-label cell50">Damage rating:</label>
+			<input type="text" id="system.damageRating" name="system.damageRating" class="cell50" value="{{system.damageRating}}" data-dtype="Number" data-min="-5" data-max="5"/>
 		</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.requiredHands" class="resource-label cell50">Hands required:</label>
-			<select id="data.requiredHands" name="data.requiredHands" class="itemValueType cell50">
-				{{#select data.requiredHands}}
+			<label for="system.requiredHands" class="resource-label cell50">Hands required:</label>
+			<select id="system.requiredHands" name="system.requiredHands" class="itemValueType cell50">
+				{{#select system.requiredHands}}
 				<option value="1">One</option>
 				<option value="2">Two</option>
 				{{/select}}
@@ -47,7 +47,7 @@
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.wounds}}" data-checkbox-group="wounds">
 			<div class="cell100">
-				Wound conditions: 
+				Wound conditions:
 				{{#each checkboxGroups.wounds.selectedItems as |wound key|}}
 				<span title="{{convertHTMLForTitle wound.description}}" class="hasTooltip">{{wound.title}}</span>{{#isNotLastItem key ../checkboxGroups.wounds.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
@@ -59,7 +59,7 @@
 			{{#each checkboxGroups.wounds.optionsData as |wound key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{wound.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle wound.description}}">{{wound.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{wound.effectID}}" data-group-type="checkbox-wound-conditions" type="checkbox" id="{{wound.key}}" name="data.woundConditions" value="{{wound.key}}" {{checked wound.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{wound.effectID}}" data-group-type="checkbox-wound-conditions" type="checkbox" id="{{wound.key}}" name="system.woundConditions" value="{{wound.key}}" {{checked wound.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -77,7 +77,7 @@
 			{{#each checkboxGroups.keywords.optionsData as |keyword key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{keyword.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle keyword.description}}">{{keyword.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="data.keywords" value="{{keyword.key}}" {{checked keyword.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="system.keywords" value="{{keyword.key}}" {{checked keyword.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -95,7 +95,7 @@
 			{{#each checkboxGroups.actions.optionsData as |action key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{action.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle action.description}}">{{action.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{action.effectID}}" data-group-type="checkbox-actions" type="checkbox" id="{{action.key}}" name="data.customActions" value="{{action.key}}" {{checked action.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{action.effectID}}" data-group-type="checkbox-actions" type="checkbox" id="{{action.key}}" name="system.customActions" value="{{action.key}}" {{checked action.checked}}/>
 			</div>
 			{{/each}}
 		</div>

--- a/templates/item/item-perk-sheet.html
+++ b/templates/item/item-perk-sheet.html
@@ -9,11 +9,11 @@
 				<label for="name">Name:</label>
 				<input name="name" type="text" value="{{item.name}}" placeholder="Name" />
 			</h1>
-			
+
 			<div class="cell100 flexRow verticalCenter flexBetween lastRow">
-				<label class="cell30" for="data.setting">{{localize "PRIME.core_setting"}}:</label>
-				<select name="data.setting" id="data.setting" class="itemRarity cell70">
-					{{#select data.setting}}
+				<label class="cell30" for="system.setting">{{localize "PRIME.core_setting"}}:</label>
+				<select name="system.setting" id="system.setting" class="itemRarity cell70">
+					{{#select system.setting}}
 					{{#each coreTables.settings}}
 					<option value="{{this.key}}">{{this.title}}</option>
 					{{/each}}
@@ -35,14 +35,14 @@
 		<div class="blockTitle">Cost</div>
 
 		<div class="cell40 flexRow flexBetween verticalCenter">
-			<label for="data.cost.amount" class="resource-label cell50 rightAlign">Amount:</label>
-			<input type="text" id="data.cost.amount" name="data.cost.amount" class="cell50" value="{{data.cost.amount}}" data-dtype="Number" data-min="0" data-max="100"/>
+			<label for="system.cost.amount" class="resource-label cell50 rightAlign">Amount:</label>
+			<input type="text" id="system.cost.amount" name="system.cost.amount" class="cell50" value="{{system.cost.amount}}" data-dtype="Number" data-min="0" data-max="100"/>
 		</div>
 
 		<div class="cell60 flexRow flexBetween verticalCenter">
-			<label for="data.cost.attributeType" class="resource-label cell20 rightAlign">Type:</label>
-			<select id="data.cost.attributeType" name="data.cost.attributeType" class="cell80" data-effect-id="{{effectID}}" data-effect-flag-key="path">
-				{{#select data.cost.attributeType}}
+			<label for="system.cost.attributeType" class="resource-label cell20 rightAlign">Type:</label>
+			<select id="system.cost.attributeType" name="system.cost.attributeType" class="cell80" data-effect-id="{{effectID}}" data-effect-flag-key="path">
+				{{#select system.cost.attributeType}}
 				{{#each perkTables.costs}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}

--- a/templates/item/item-prime-sheet.html
+++ b/templates/item/item-prime-sheet.html
@@ -10,9 +10,9 @@
 				<input name="name" type="text" value="{{item.name}}" placeholder="Name" />
 			</h1>
 			<div class="cell100 flexRow verticalCenter flexBetween lastRow">
-				<label class="cell30" for="data.setting">{{localize "PRIME.core_setting"}}:</label>
-				<select name="data.setting" id="data.setting" class="primeSetting cell70">
-					{{#select data.setting}}
+				<label class="cell30" for="system.setting">{{localize "PRIME.core_setting"}}:</label>
+				<select name="system.setting" id="system.setting" class="primeSetting cell70">
+					{{#select system.setting}}
 					{{#each coreTables.settings}}
 					<option value="{{this.key}}">{{this.title}}</option>
 					{{/each}}
@@ -20,9 +20,9 @@
 				</select>
 			</div>
 			<div class="cell100 flexRow verticalCenter flexBetween lastRow">
-				<label class="cell30" for="data.statType">{{localize "PRIME.core_stat_type"}}:</label>
-				<select name="data.statType" id="data.statType" class="primeSetting cell70">
-					{{#select data.statType}}
+				<label class="cell30" for="system.statType">{{localize "PRIME.core_stat_type"}}:</label>
+				<select name="system.statType" id="system.statType" class="primeSetting cell70">
+					{{#select system.statType}}
 					<option value="physical">{{localize "PRIME.stat_type_physical"}}</option>
 					<option value="mental">{{localize "PRIME.stat_type_mental"}}</option>
 					<option value="supernatural">{{localize "PRIME.stat_type_supernatural"}}</option>
@@ -31,17 +31,17 @@
 			</div>
 			<div class="cell100 flexRow verticalCenter flexBetween">
 				<div class="cell50 flexRow verticalCenter lastRow">
-					<label for="data.default" class="resource-label cell80 rightAlign" title="Action is available to all characters by default.">Default:</label>
-					<input type="checkbox" id="data.default" name="data.default" class="cell20" {{checked data.default}}/>
+					<label for="system.default" class="resource-label cell80 rightAlign" title="Action is available to all characters by default.">Default:</label>
+					<input type="checkbox" id="system.default" name="system.default" class="cell20" {{checked system.default}}/>
 				</div>
 				<div class="cell50 flexRow verticalCenter lastRow">
-					<label for="data.customisable" class="resource-label cell80 rightAlign" title="Action can be edited when added to the character.">Customisable:</label>
-					<input type="checkbox" id="data.customisable" name="data.customisable" class="cell20" {{checked data.customisable}}/>
+					<label for="system.customisable" class="resource-label cell80 rightAlign" title="Action can be edited when added to the character.">Customisable:</label>
+					<input type="checkbox" id="system.customisable" name="system.customisable" class="cell20" {{checked system.customisable}}/>
 				</div>
 			</div>
 		</div>
 	</div>
-	
+
 	{{> itemDescription }}
 
 	{{> itemMetadata }}

--- a/templates/item/item-ranged-weapon-sheet.html
+++ b/templates/item/item-ranged-weapon-sheet.html
@@ -9,12 +9,12 @@
 
 	<div class="flexRow flexWrap flexBetween block infoBlock">
 		<div class="blockTitle">Weapon details</div>
-		
+
 		<div class="cell50 flexRow verticalCenter flexBetween">
-			<label for="data.weaponSize" class="resource-label cell50">Size:</label>
-			<!--<input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />-->
-			<select name="data.weaponSize" class="itemValueType cell50">
-				{{#select data.weaponSize}}
+			<label for="system.weaponSize" class="resource-label cell50">Size:</label>
+			<!--<input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />-->
+			<select name="system.weaponSize" class="itemValueType cell50">
+				{{#select system.weaponSize}}
 				{{#each itemTables.weapons.sizes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -22,10 +22,10 @@
 			</select>
 		</div>
 		<div class="cell50 flexRow verticalCenter flexBetween">
-			<label for="data.weaponType" class="resource-label cell50">Type:</label>
-			<!--<input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />-->
-			<select id="data.weaponType" name="data.weaponType" class="cell50">
-				{{#select data.weaponType}}
+			<label for="system.weaponType" class="resource-label cell50">Type:</label>
+			<!--<input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />-->
+			<select id="system.weaponType" name="system.weaponType" class="cell50">
+				{{#select system.weaponType}}
 				{{#each itemTables.weapons.rangedTypes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -33,13 +33,13 @@
 			</select>
 		</div>
 		<div class="cell50 flexRow verticalCenter flexBetween">
-			<label for="data.damageRating" class="resource-label cell50">Damage rating:</label>
-			<input type="text" id="data.damageRating" name="data.damageRating" class="cell50" value="{{data.damageRating}}" data-dtype="Number" data-min="-5" data-max="5"/>
+			<label for="system.damageRating" class="resource-label cell50">Damage rating:</label>
+			<input type="text" id="system.damageRating" name="system.damageRating" class="cell50" value="{{system.damageRating}}" data-dtype="Number" data-min="-5" data-max="5"/>
 		</div>
 		<div class="cell50 flexRow verticalCenter flexBetween">
-			<label for="data.requiredHands" class="resource-label cell50">Hands required:</label>
-			<select id="data.requiredHands" name="data.requiredHands" class="itemValueType cell50">
-				{{#select data.requiredHands}}
+			<label for="system.requiredHands" class="resource-label cell50">Hands required:</label>
+			<select id="system.requiredHands" name="system.requiredHands" class="itemValueType cell50">
+				{{#select system.requiredHands}}
 				<option value="1">One</option>
 				<option value="2">Two</option>
 				{{/select}}
@@ -48,7 +48,7 @@
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.wounds}}" data-checkbox-group="wounds">
 			<div class="cell100">
-				Wound conditions: 
+				Wound conditions:
 				{{#each checkboxGroups.wounds.selectedItems as |wound key|}}
 				<span title="{{convertHTMLForTitle wound.description}}" class="hasTooltip">{{wound.title}}</span>{{#isNotLastItem key ../checkboxGroups.wounds.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
@@ -60,7 +60,7 @@
 			{{#each checkboxGroups.wounds.optionsData as |wound key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{wound.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle wound.description}}">{{wound.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{wound.effectID}}" data-group-type="checkbox-wound-conditions" type="checkbox" id="{{wound.key}}" name="data.woundConditions" value="{{wound.key}}" {{checked wound.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{wound.effectID}}" data-group-type="checkbox-wound-conditions" type="checkbox" id="{{wound.key}}" name="system.woundConditions" value="{{wound.key}}" {{checked wound.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -78,7 +78,7 @@
 			{{#each checkboxGroups.keywords.optionsData as |keyword key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{keyword.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle keyword.description}}">{{keyword.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="data.keywords" value="{{keyword.key}}" {{checked keyword.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="system.keywords" value="{{keyword.key}}" {{checked keyword.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -96,7 +96,7 @@
 			{{#each checkboxGroups.actions.optionsData as |action key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{action.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle action.description}}">{{action.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{action.effectID}}" data-group-type="checkbox-actions" type="checkbox" id="{{action.key}}" name="data.customActions" value="{{action.key}}" {{checked action.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{action.effectID}}" data-group-type="checkbox-actions" type="checkbox" id="{{action.key}}" name="system.customActions" value="{{action.key}}" {{checked action.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -104,11 +104,11 @@
 
 	<div class="flexRow block flexWrap verticalCenter infoBlock">
 		<div class="blockTitle">Ranges</div>
-		{{#each data.ranges as |rangeBlock key|}}
+		{{#each system.ranges as |rangeBlock key|}}
 		<div class="cell33 flexRow flexBetween">
 			<div class="cell70 flexRow flexEnd verticalCenter">{{localize rangeBlock.title}}: </div>
 			<div class="cell30">
-				<input type="text" id="data.ranges.{{key}}.value" name="data.ranges.{{key}}.value" class="cell100" value="{{rangeBlock.value}}" data-dtype="Number"/>
+				<input type="text" id="system.ranges.{{key}}.value" name="system.ranges.{{key}}.value" class="cell100" value="{{rangeBlock.value}}" data-dtype="Number"/>
 			</div>
 		</div>
 		{{/each}}
@@ -117,14 +117,14 @@
 	<div class="flexRow block flexWrap flexBetween verticalCenter infoBlock">
 		<div class="blockTitle">Ammunition</div>
 		<div class="cell50 flexRow flexBetween verticalCenter">
-			<label for="data.ammo.capacity" class="resource-label cell50">Capacity:</label>
-			<input type="text" id="data.ammo.capacity" name="data.ammo.capacity" class="cell50" value="{{data.ammo.capacity}}" data-dtype="Number"/>
+			<label for="system.ammo.capacity" class="resource-label cell50">Capacity:</label>
+			<input type="text" id="system.ammo.capacity" name="system.ammo.capacity" class="cell50" value="{{system.ammo.capacity}}" data-dtype="Number"/>
 		</div>
 		<div class="cell50 flexRow flexBetween verticalCenter">
-			<label for="data.ammo.type" class="resource-label cell50">Type:</label>
-			<!--<input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />-->
-			<select id="data.ammo.type" name="data.ammo.type" class="cell50">
-				{{#select data.ammo.type}}
+			<label for="system.ammo.type" class="resource-label cell50">Type:</label>
+			<!--<input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />-->
+			<select id="system.ammo.type" name="system.ammo.type" class="cell50">
+				{{#select system.ammo.type}}
 				{{#each itemTables.weapons.ammoTypes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}

--- a/templates/item/item-refinement-sheet.html
+++ b/templates/item/item-refinement-sheet.html
@@ -10,9 +10,9 @@
 				<input name="name" type="text" value="{{item.name}}" placeholder="Name" />
 			</h1>
 			<div class="cell100 flexRow verticalCenter flexBetween">
-				<label class="cell30" for="data.setting">{{localize "PRIME.core_setting"}}:</label>
-				<select name="data.setting" id="data.setting" class="primeSetting cell70">
-					{{#select data.setting}}
+				<label class="cell30" for="system.setting">{{localize "PRIME.core_setting"}}:</label>
+				<select name="system.setting" id="system.setting" class="primeSetting cell70">
+					{{#select system.setting}}
 					{{#each coreTables.settings}}
 					<option value="{{this.key}}">{{this.title}}</option>
 					{{/each}}
@@ -20,9 +20,9 @@
 				</select>
 			</div>
 			<div class="cell100 flexRow verticalCenter flexBetween">
-				<label class="cell30" for="data.statType">{{localize "PRIME.core_stat_type"}}:</label>
-				<select name="data.statType" id="data.statType" class="primeSetting cell70">
-					{{#select data.statType}}
+				<label class="cell30" for="system.statType">{{localize "PRIME.core_stat_type"}}:</label>
+				<select name="system.statType" id="system.statType" class="primeSetting cell70">
+					{{#select system.statType}}
 					<option value="physical">{{localize "PRIME.stat_type_physical"}}</option>
 					<option value="mental">{{localize "PRIME.stat_type_mental"}}</option>
 					<option value="supernatural">{{localize "PRIME.stat_type_supernatural"}}</option>
@@ -31,17 +31,17 @@
 			</div>
 			<div class="cell100 flexRow verticalCenter flexBetween">
 				<div class="cell50 flexRow verticalCenter lastRow">
-					<label for="data.default" class="resource-label cell80 rightAlign" title="Action is available to all characters by default.">Default:</label>
-					<input type="checkbox" id="data.default" name="data.default" class="cell20" {{checked data.default}}/>
+					<label for="system.default" class="resource-label cell80 rightAlign" title="Action is available to all characters by default.">Default:</label>
+					<input type="checkbox" id="system.default" name="system.default" class="cell20" {{checked system.default}}/>
 				</div>
 				<div class="cell50 flexRow verticalCenter lastRow">
-					<label for="data.customisable" class="resource-label cell80 rightAlign" title="Action can be edited when added to the character.">Customisable:</label>
-					<input type="checkbox" id="data.customisable" name="data.customisable" class="cell20" {{checked data.customisable}}/>
+					<label for="system.customisable" class="resource-label cell80 rightAlign" title="Action can be edited when added to the character.">Customisable:</label>
+					<input type="checkbox" id="system.customisable" name="system.customisable" class="cell20" {{checked system.customisable}}/>
 				</div>
 			</div>
 		</div>
 	</div>
-	
+
 	{{> itemDescription }}
 
 	{{> itemMetadata }}

--- a/templates/item/item-shield-sheet.html
+++ b/templates/item/item-shield-sheet.html
@@ -9,23 +9,23 @@
 	<div class="flexRow flexWrap block infoBlock">
 		<div class="blockTitle">Block bonus</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.meleeBlockBonus" class="resource-label cell50">Melee:</label>
-			<input type="text" id="data.meleeBlockBonus" name="data.meleeBlockBonus" class="cell50" value="{{data.meleeBlockBonus}}" data-dtype="Number" data-min="-10" data-max="10"/>
+			<label for="system.meleeBlockBonus" class="resource-label cell50">Melee:</label>
+			<input type="text" id="system.meleeBlockBonus" name="system.meleeBlockBonus" class="cell50" value="{{system.meleeBlockBonus}}" data-dtype="Number" data-min="-10" data-max="10"/>
 		</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.rangedBlockBonus" class="resource-label cell50">Ranged:</label>
-			<input type="text" id="data.rangedBlockBonus" name="data.rangedBlockBonus" class="cell50" value="{{data.rangedBlockBonus}}" data-dtype="Number" data-min="-10" data-max="10"/>
+			<label for="system.rangedBlockBonus" class="resource-label cell50">Ranged:</label>
+			<input type="text" id="system.rangedBlockBonus" name="system.rangedBlockBonus" class="cell50" value="{{system.rangedBlockBonus}}" data-dtype="Number" data-min="-10" data-max="10"/>
 		</div>
 	</div>
-	
+
 	<div class="flexRow flexWrap block infoBlock">
 		<div class="blockTitle">Combat abilities (optional)</div>
-		
+
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.weaponSize" class="resource-label cell50">Size:</label>
-			<!--<input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />-->
-			<select name="data.weaponSize" class="weaponSize cell50">
-				{{#select data.weaponSize}}
+			<label for="system.weaponSize" class="resource-label cell50">Size:</label>
+			<!--<input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />-->
+			<select name="system.weaponSize" class="weaponSize cell50">
+				{{#select system.weaponSize}}
 				{{#each itemTables.weapons.sizes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -33,10 +33,10 @@
 			</select>
 		</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.weaponType" class="resource-label cell50">Type:</label>
-			<!--<input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />-->
-			<select id="data.weaponType" name="data.weaponType" class="cell50">
-				{{#select data.weaponType}}
+			<label for="system.weaponType" class="resource-label cell50">Type:</label>
+			<!--<input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />-->
+			<select id="system.weaponType" name="system.weaponType" class="cell50">
+				{{#select system.weaponType}}
 				{{#each itemTables.weapons.meleeTypes}}
 				<option value="{{this.key}}">{{this.title}}</option>
 				{{/each}}
@@ -44,13 +44,13 @@
 			</select>
 		</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.damageRating" class="resource-label cell50">Damage rating:</label>
-			<input type="text" id="data.damageRating" name="data.damageRating" class="cell50" value="{{data.damageRating}}" data-dtype="Number" data-min="-5" data-max="5"/>
+			<label for="system.damageRating" class="resource-label cell50">Damage rating:</label>
+			<input type="text" id="system.damageRating" name="system.damageRating" class="cell50" value="{{system.damageRating}}" data-dtype="Number" data-min="-5" data-max="5"/>
 		</div>
 		<div class="cell50 flexRow verticalCenter">
-			<label for="data.requiredHands" class="resource-label cell50">Hands required:</label>
-			<select id="data.requiredHands" name="data.requiredHands" class="itemValueType cell50">
-				{{#select data.requiredHands}}
+			<label for="system.requiredHands" class="resource-label cell50">Hands required:</label>
+			<select id="system.requiredHands" name="system.requiredHands" class="itemValueType cell50">
+				{{#select system.requiredHands}}
 				<option value="1">One</option>
 				<option value="2">Two</option>
 				{{/select}}
@@ -71,7 +71,7 @@
 			{{#each checkboxGroups.wounds.optionsData as |wound key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{wound.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle wound.description}}">{{wound.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{wound.effectID}}" data-group-type="checkbox-wound-conditions" type="checkbox" id="{{wound.key}}" name="data.woundConditions" value="{{wound.key}}" {{checked wound.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{wound.effectID}}" data-group-type="checkbox-wound-conditions" type="checkbox" id="{{wound.key}}" name="system.woundConditions" value="{{wound.key}}" {{checked wound.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -89,7 +89,7 @@
 			{{#each checkboxGroups.keywords.optionsData as |keyword key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{keyword.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle keyword.description}}">{{keyword.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="data.keywords" value="{{keyword.key}}" {{checked keyword.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{keyword.effectID}}" data-group-type="checkbox-keywords" type="checkbox" id="{{keyword.key}}" name="system.keywords" value="{{keyword.key}}" {{checked keyword.checked}}/>
 			</div>
 			{{/each}}
 		</div>
@@ -107,7 +107,7 @@
 			{{#each checkboxGroups.actions.optionsData as |action key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
 				<label for="{{action.key}}" class="resource-label hasTooltip" title="{{convertHTMLForTitle action.description}}">{{action.title}}:</label>
-				<input class="checkboxGroup" data-effect-id="{{action.effectID}}" data-group-type="checkbox-actions" type="checkbox" id="{{action.key}}" name="data.customActions" value="{{action.key}}" {{checked action.checked}}/>
+				<input class="checkboxGroup" data-effect-id="{{action.effectID}}" data-group-type="checkbox-actions" type="checkbox" id="{{action.key}}" name="system.customActions" value="{{action.key}}" {{checked action.checked}}/>
 			</div>
 			{{/each}}
 		</div>

--- a/templates/item/partials/cards/item-card-action.html
+++ b/templates/item/partials/cards/item-card-action.html
@@ -1,19 +1,19 @@
 <div class="primeCard itemCard itemCardAction {{partialClasses}}">
-    <div class="cardTitle"><a class="itemTitle" data-item-id="{{this.data._id}}">{{this.data.name}}</a></div>
-    <div class="cardTopRightDetail titled"><div class="tinyTitle">AP</div>{{this.data.data.points}}</div>
-    
+    <div class="cardTitle"><a class="itemTitle" data-item-id="{{this.itemID}}">{{this.name}}</a></div>
+    <div class="cardTopRightDetail titled"><div class="tinyTitle">AP</div>{{this.system.points}}</div>
+
 	<div class="cardDetail">
 		<div class="cardDescription">
-			{{#if this.data.data.description}}
-			<div>{{{this.data.data.description}}}</div>
+			{{#if this.system.description}}
+			<div>{{{this.system.description}}}</div>
 			{{/if}}
 
-			{{#if this.data.data.settingDescription}}
-			<div>{{{this.data.data.settingDescription}}}</div>
+			{{#if this.system.settingDescription}}
+			<div>{{{this.system.settingDescription}}}</div>
 			{{/if}}
 		</div>
 
-		{{#if this.data.data.default}}
+		{{#if this.system.default}}
 		<div class="cardBottomRightDetail isDefaultIcon defaultIcon hasTooltip" title="Default action">D</div>
 		{{else}}
 		<div class="cardBottomRightDetail isDefaultIcon purchasedIcon hasTooltip" title="Perk purchased to unlock action">$</div>

--- a/templates/item/partials/cards/item-card-perk.html
+++ b/templates/item/partials/cards/item-card-perk.html
@@ -1,5 +1,5 @@
 <div class="primeCard itemCard itemCardPerk {{partialClasses}}" data-item-index="{{itemIndex}}">
-    <div class="cardTitle"><a class="itemTitle stopDrag" data-item-id="{{this._id}}">{{this.name}}</a></div>
+    <div class="cardTitle"><a class="itemTitle stopDrag" data-item-id="{{this.itemID}}">{{this.name}}</a></div>
     <div class="cardTopRightDetail">{{this.data.cost.amount}}</div>
 
 	<div class="cardDetail stopDrag">
@@ -13,7 +13,7 @@
 			{{/if}}
 		</div>
 
-		<div class="cardBottomRightDetail removePerk"><a class="deleteItemIcon stopDrag" data-item-id={{this._id}}><i class="fas fa-trash stopDrag stopClose"></i></a></div>
+		<div class="cardBottomRightDetail removePerk"><a class="deleteItemIcon stopDrag" data-item-id={{this.itemID}}><i class="fas fa-trash stopDrag stopClose"></i></a></div>
 
 		{{#ifCond this.data.cost.attributeType "==" "perkCostXP" }}
 		<div class="cardRightCenterDetail perkCost hasTooltip" title="Perk cost XP">XP</div>

--- a/templates/item/partials/cards/item-card-perk.html
+++ b/templates/item/partials/cards/item-card-perk.html
@@ -1,7 +1,7 @@
 <div class="primeCard itemCard itemCardPerk {{partialClasses}}" data-item-index="{{itemIndex}}">
     <div class="cardTitle"><a class="itemTitle stopDrag" data-item-id="{{this._id}}">{{this.name}}</a></div>
     <div class="cardTopRightDetail">{{this.data.cost.amount}}</div>
-    
+
 	<div class="cardDetail stopDrag">
 		<div class="cardDescription">
 			{{#if this.data.description}}


### PR DESCRIPTION
- Added handlebars debug
- Added `itemID` when collecting/sorting actions as both `_id` and `id` where being stripped out when sent to handlebars - lord alone knows why!


- Adjusted item sheet data to match actor sheet in style.


- Adjusted to use new item sheet data.


- Whitespace tidy up.