### PR TITLE
FIX: html-in-equipment-table-title-attributes

### DIFF
--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1,4 +1,5 @@
 import { PrimeTables } from "../prime_tables.js";
+import { prepForTitleAttribute } from "../utils/strings.js";
 
 /**
  * Extend the basic Item with some very simple modifications.
@@ -115,7 +116,7 @@ export class PrimeItem extends Item
                 let currLookupItem = lookupTable[count];
                 if (effect.flags[currLookupItem.key])
                 {
-                    let titleText = "<span title='" + currLookupItem.description + "' class='hasTooltip'>" + currLookupItem.title + "</span>";
+                    let titleText = "<span title='" + prepForTitleAttribute(currLookupItem.description) + "' class='hasTooltip'>" + currLookupItem.title + "</span>";
 
                     if (!currLookupItem.description)
                     {
@@ -128,7 +129,7 @@ export class PrimeItem extends Item
                         {
                             description += currLookupItem.source.system.settingDescription;
                         }
-                        titleText = "<span title='" + description + "' class='hasTooltip'>" + currLookupItem.title + "</span>";
+                        titleText = "<span title='" + prepForTitleAttribute(description) + "' class='hasTooltip'>" + currLookupItem.title + "</span>";
                     }
 
                     titlesArray.push(titleText);

--- a/module/utils/strings.js
+++ b/module/utils/strings.js
@@ -1,0 +1,25 @@
+export const prepForTitleAttribute = (value) =>
+{
+    let parsedValue = convertHtmlToText(value);
+    parsedValue = escapeText(parsedValue);
+    return parsedValue;
+};
+
+export const convertHtmlToText = (value) =>
+{
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = value;
+    return tempDiv.innerText;
+};
+
+export const escapeText = (value) =>
+{
+    let escapeValue = value
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+
+    return escapeValue;
+};


### PR DESCRIPTION
Added output escaping to text for title attributes that removes HTML tags and encodes common string breaking characters.