### PR TITLE
FIX: Prevent keywords and custom actions being edited on owned items

### DIFF
--- a/css/elements/item_sheets/prime_base_item_sheet.css
+++ b/css/elements/item_sheets/prime_base_item_sheet.css
@@ -40,12 +40,12 @@
 	margin-bottom: 0px;
 }
 
-.checkboxGroupTitle:hover
+.globalItem .checkboxGroupTitle:hover
 {
 	cursor: pointer;
 }
 
-.checkboxGroupTitle:hover div
+.globalItem .checkboxGroupTitle:hover div
 {
 	text-decoration: underline;
 }

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -82,6 +82,8 @@ export class PrimeItemSheet extends ItemSheet
         const source = this.item.toObject();
         sheetData.source = source.system;
 
+        sheetData.cssClass = this.item.isOwned ? "ownedItem" : "globalItem";
+
         return sheetData;
     }
 

--- a/templates/item/item-armour-sheet.html
+++ b/templates/item/item-armour-sheet.html
@@ -37,9 +37,12 @@
 				<span title="{{convertHTMLForTitle keyword.description}}" class="hasTooltip">{{keyword.title}}</span>{{#isNotLastItem key ../checkboxGroups.keywords.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.keywords}}" data-checkbox-group="keywords">
 			{{#each checkboxGroups.keywords.optionsData as |keyword key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -48,6 +51,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.actions}}" data-checkbox-group="actions">
 			<div class="cell100">Untrained penalty:
@@ -55,9 +59,12 @@
 				<span title="{{convertHTMLForTitle untrainedPenalty.description}}" class="hasTooltip">{{untrainedPenalty.title}}</span>{{#isNotLastItem key ../checkboxGroups.untrainedPenalty.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 lastRow flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.actions}}" data-checkbox-group="actions">
 			{{#each checkboxGroups.untrainedPenalty.optionsData as |untrainedPenalty key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -66,6 +73,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 	</div>
 
 	{{> itemValue }}

--- a/templates/item/item-melee-weapon-sheet.html
+++ b/templates/item/item-melee-weapon-sheet.html
@@ -52,9 +52,12 @@
 				<span title="{{convertHTMLForTitle wound.description}}" class="hasTooltip">{{wound.title}}</span>{{#isNotLastItem key ../checkboxGroups.wounds.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.wounds}}" data-checkbox-group="wounds">
 			{{#each checkboxGroups.wounds.optionsData as |wound key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -63,6 +66,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.keywords}}" data-checkbox-group="keywords">
 			<div class="cell100">Keywords:
@@ -70,9 +74,12 @@
 				<span title="{{convertHTMLForTitle keyword.description}}" class="hasTooltip">{{keyword.title}}</span>{{#isNotLastItem key ../checkboxGroups.keywords.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.keywords}}" data-checkbox-group="keywords">
 			{{#each checkboxGroups.keywords.optionsData as |keyword key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -81,6 +88,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.actions}}" data-checkbox-group="actions">
 			<div class="cell100">Custom actions:
@@ -88,9 +96,12 @@
 				<span title="{{convertHTMLForTitle action.description}}" class="hasTooltip">{{action.title}}</span>{{#isNotLastItem key ../checkboxGroups.actions.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 lastRow flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.actions}}" data-checkbox-group="actions">
 			{{#each checkboxGroups.actions.optionsData as |action key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -99,6 +110,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 	</div>
 
 	{{> itemValue }}

--- a/templates/item/item-ranged-weapon-sheet.html
+++ b/templates/item/item-ranged-weapon-sheet.html
@@ -53,9 +53,12 @@
 				<span title="{{convertHTMLForTitle wound.description}}" class="hasTooltip">{{wound.title}}</span>{{#isNotLastItem key ../checkboxGroups.wounds.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.wounds}}" data-checkbox-group="wounds">
 			{{#each checkboxGroups.wounds.optionsData as |wound key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -64,6 +67,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.keywords}}" data-checkbox-group="keywords">
 			<div class="cell100">Keywords:
@@ -71,9 +75,12 @@
 				<span title="{{convertHTMLForTitle keyword.description}}" class="hasTooltip">{{keyword.title}}</span>{{#isNotLastItem key ../checkboxGroups.keywords.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.keywords}}" data-checkbox-group="keywords">
 			{{#each checkboxGroups.keywords.optionsData as |keyword key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -82,6 +89,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 
 		<div class="cell100 flexRow verticalCenter flexCenter checkboxGroupTitle {{checkboxGroupState checkboxGroupStates.actions}}" data-checkbox-group="actions">
 			<div class="cell100">Custom actions:
@@ -89,9 +97,12 @@
 				<span title="{{convertHTMLForTitle action.description}}" class="hasTooltip">{{action.title}}</span>{{#isNotLastItem key ../checkboxGroups.actions.selectedItems.length}}, {{/isNotLastItem}}
 				{{/each}}
 			</div>
+			{{#unless isOwned}}
 			<i class="fas fa-chevron-circle-up"></i>
 			<i class="fas fa-chevron-circle-down"></i>
+			{{/unless}}
 		</div>
+		{{#unless isOwned}}
 		<div class="cell100 lastRow flexRow verticalCenter flexBetween flexWrap checkboxGroupWrapper {{checkboxGroupState checkboxGroupStates.actions}}" data-checkbox-group="actions">
 			{{#each checkboxGroups.actions.optionsData as |action key|}}
 			<div class="flexRow verticalCenter cell33 flexBetween">
@@ -100,6 +111,7 @@
 			</div>
 			{{/each}}
 		</div>
+		{{/unless}}
 	</div>
 
 	<div class="flexRow block flexWrap verticalCenter infoBlock">


### PR DESCRIPTION
- Added logic to item sheet templates to prevent editing of keywords, actions and injury types for owned items.
- Tidied up the CSS to prevent confusion about missing interactions.
