### PR TITLE
FIX: Extended character count breaks inventory

### DIFF
--- a/module/migrations/prime_data_migrations_manager.js
+++ b/module/migrations/prime_data_migrations_manager.js
@@ -89,6 +89,8 @@ export class PrimeDataMigrationManager
         case "0.10.0":
             PrimeMigration_0_7_0_and_0_8_0_to_0_10_1.update();
             break;
+        case "0.10.1":
+            break;
         default:
             this.migrationError(currentWorldVersion, systemVersion);
             break;

--- a/module/prime_handlebars.js
+++ b/module/prime_handlebars.js
@@ -1,4 +1,5 @@
 import { PrimeTables } from "./prime_tables.js";
+import { prepForTitleAttribute } from "./utils/strings.js";
 
 var primeHandlebarsPartialsPaths =
 {
@@ -68,6 +69,7 @@ Handlebars.registerHelper("convertHTMLForTitle", function (html, maxChars)
         {
             html = html.slice(0,150) + "...";
         }
+        html = prepForTitleAttribute(html);
     }
     return html;
 });
@@ -108,7 +110,7 @@ Handlebars.registerHelper("for", function(from, to, incr, block)
 Handlebars.registerHelper("ifCond", function (v1, operator, v2, options) 
 {
 
-    switch (operator) 
+    switch (operator)
     {
     case "==":
         return (v1 == v2) ? options.fn(this) : options.inverse(this);
@@ -237,7 +239,7 @@ Handlebars.registerHelper("cropToLength", function(value, cropLength)
 });
 
 // Usage: {{log this}}
-Handlebars.registerHelper("log", function(messageData) 
+Handlebars.registerHelper("log", function(messageData)
 {
     console.log(`HB log: ${messageData}`, messageData);
 });

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "prime",
   "title": "Prime system",
   "description": "The foundry VTT system of the Prime RPG as used in the Possession world.",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "compatibility": {
     "minimum": "0.10.291",
     "verified": 10,
@@ -53,6 +53,6 @@
   "secondaryTokenAttribute": "power",
   "url": "https://github.com/johnc303/prime/",
   "manifest": "https://raw.githubusercontent.com/johnc303/prime/foundry-v10/system.json",
-  "download": "https://github.com/prime-foundry/prime/releases/download/0.10.1/release.zip",
+  "download": "https://github.com/prime-foundry/prime/releases/download/0.11.0/release.zip",
   "license": "LICENSE2.txt"
 }

--- a/templates/item/partials/list/item-list-general.html
+++ b/templates/item/partials/list/item-list-general.html
@@ -1,5 +1,3 @@
-
-
 <div class="{{partialClasses}} generalItems block">
     <div class="blockTitle">All items</div>
     <div class="primeTableWrapper">
@@ -16,7 +14,7 @@
                 {{#each inventoryItems as |item index|}}
                 <tr class="draggableItem inventoryItem" data-item-index="{{index}}">
                     <td title="{{convertHTMLForTitle item.name}}"><a class="itemTitle stopDrag" data-item-id="{{item.itemID}}"><i class="fas fa-external-link-alt fa-xs"></i><i class="fas fa-info-circle fa-xs"></i> {{cropToLength item.name 55}}</a></td>
-                    <td title="{{convertHTMLForTitle item.system.description}}">{{{cropToLength item.system.description 55}}}</td>
+                    <td title="{{convertHTMLForTitle item.system.description}}">{{{convertHTMLForTitle item.system.description 55}}}</td>
                     <td class="center"><a class="deleteItemIcon stopDrag" data-item-id={{item.itemID}}><i class="fas fa-trash stopDrag"></i></a></td>
                 </tr>
                 {{/each}}


### PR DESCRIPTION
Bumped version number.
Added output escaping for the description field as items with descriptions were breaking the inventory list (more to do).

#minor